### PR TITLE
feat: added ability to render sitemap and robots.txt as pages without api prefix

### DIFF
--- a/api/sitemap.xml.ts
+++ b/api/sitemap.xml.ts
@@ -1,8 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { SiteMap } from '../lib/types'
-import { host } from '../lib/config'
-import { getSiteMaps } from '../lib/get-site-maps'
+import { host, sitemapOnlyPageUrlOverridden } from '../lib/config'
+import { getOnlyUrlOverriddenSiteMaps, getSiteMaps } from '../lib/get-site-maps'
+import * as config  from '../lib/config'
+import * as types from '../lib/types'
 
 export default async (
   req: NextApiRequest,
@@ -12,7 +14,12 @@ export default async (
     return res.status(405).send({ error: 'method not allowed' })
   }
 
-  const siteMaps = await getSiteMaps()
+  let siteMaps: types.SiteMap[]
+  if (sitemapOnlyPageUrlOverridden) {
+    siteMaps = await getOnlyUrlOverriddenSiteMaps()
+  } else {
+    siteMaps = await getSiteMaps()
+  }
 
   // cache sitemap for up to one hour
   res.setHeader(

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,6 +36,8 @@ export const pageUrlAdditions = cleanPageUrlMap(
   'pageUrlAdditions'
 )
 
+export const sitemapOnlyPageUrlOverridden = getSiteConfig('sitemapOnlyPageUrlOverridden')
+
 // general site config
 export const name: string = getSiteConfig('name')
 export const author: string = getSiteConfig('author')

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -38,6 +38,8 @@ export const pageUrlAdditions = cleanPageUrlMap(
 
 export const sitemapOnlyPageUrlOverridden = getSiteConfig('sitemapOnlyPageUrlOverridden')
 
+export const removeApiPrefixFromSitemapAndRobotsTxtPages = getSiteConfig('removeApiPrefixFromSitemapAndRobotsTxtPages')
+
 // general site config
 export const name: string = getSiteConfig('name')
 export const author: string = getSiteConfig('author')

--- a/lib/get-site-maps.ts
+++ b/lib/get-site-maps.ts
@@ -37,12 +37,14 @@ export async function getSiteMaps(): Promise<types.SiteMap[]> {
 
 export async function getOnlyUrlOverriddenSiteMaps(): Promise<types.SiteMap[]> {
   return (await getSiteMaps()).map(sm => {
-    sm.canonicalPageMap = Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
-      if (config.pageUrlOverrides[cp_name]) {
-        acc[cp_name] = cp_value
-      }
-      return acc
-    }, {})
-    return sm
+    return {
+      ...sm,
+      canonicalPageMap: Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
+        if (config.pageUrlOverrides[cp_name]) {
+          acc[cp_name] = cp_value
+        }
+        return acc
+      }, {})
+    }
   })
 }

--- a/lib/get-site-maps.ts
+++ b/lib/get-site-maps.ts
@@ -3,6 +3,7 @@ import pMap from 'p-map'
 import { getAllPages } from './get-all-pages'
 import { getSites } from './get-sites'
 import * as types from './types'
+import * as config from "./config"
 
 export async function getSiteMaps(): Promise<types.SiteMap[]> {
   const sites = await getSites()
@@ -32,4 +33,16 @@ export async function getSiteMaps(): Promise<types.SiteMap[]> {
   )
 
   return siteMaps.filter(Boolean)
+}
+
+export async function getOnlyUrlOverriddenSiteMaps(): Promise<types.SiteMap[]> {
+  return (await getSiteMaps()).map(sm => {
+    sm.canonicalPageMap = Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
+      if (config.pageUrlOverrides[cp_name]) {
+        acc[cp_name] = cp_value
+      }
+      return acc
+    }, {})
+    return sm
+  })
 }

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -1,21 +1,14 @@
 import React from 'react'
-import { isDev, domain } from 'lib/config'
+import { isDev, domain, removeApiPrefixFromSitemapAndRobotsTxtPages } from 'lib/config'
 import { getSiteMaps } from 'lib/get-site-maps'
 import { resolveNotionPage } from 'lib/resolve-notion-page'
 import { NotionPage } from 'components'
+import { GetStaticProps } from 'next'
 
-export const getStaticProps = async (context) => {
+export const getStaticProps: GetStaticProps = async (context) => {
   const rawPageId = context.params.pageId as string
 
   try {
-    if (rawPageId === 'sitemap.xml' || rawPageId === 'robots.txt') {
-      return {
-        redirect: {
-          destination: `/api/${rawPageId}`
-        }
-      }
-    }
-
     const props = await resolveNotionPage(domain, rawPageId)
 
     return { props, revalidate: 10 }

--- a/pages/robots.txt.tsx
+++ b/pages/robots.txt.tsx
@@ -1,0 +1,40 @@
+import { GetServerSideProps, GetStaticProps } from 'next'
+import { host, removeApiPrefixFromSitemapAndRobotsTxtPages } from '../lib/config'
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  if (!removeApiPrefixFromSitemapAndRobotsTxtPages) {
+    return {
+      redirect: {
+        destination: `/api/robots.txt`,
+        statusCode: 301,
+      }
+    }
+  }
+
+  if (req.method !== 'GET') {
+    res.statusCode = 405
+    res.setHeader("Content-Type", "application/json")
+    res.write(JSON.stringify({ error: "method not allowed" }))
+    res.end()
+    return {
+      props: {}
+    }
+  }
+
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=60, max-age=60, stale-while-revalidate=60'
+  )
+  res.setHeader('Content-Type', 'text/plain')
+  res.write(`User-agent: *
+Sitemap: ${host}/sitemap.xml
+  `)
+  res.end()
+  return {
+    props: {}
+  }
+}
+
+const RobotsTxt: React.FC = () => null
+
+export default RobotsTxt

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,78 @@
+import { GetServerSideProps } from 'next'
+
+import { CanonicalPageMap, SiteMap } from '../lib/types'
+import { host, removeApiPrefixFromSitemapAndRobotsTxtPages, sitemapOnlyPageUrlOverridden } from '../lib/config'
+import { getOnlyUrlOverriddenSiteMaps, getSiteMaps } from '../lib/get-site-maps'
+import * as types from '../lib/types'
+
+export const getServerSideProps: GetServerSideProps = async (
+  { req,
+    res }
+    ) => {
+  if (!removeApiPrefixFromSitemapAndRobotsTxtPages) {
+    return {
+      redirect: {
+        destination: `/api/sitemap.xml`,
+        statusCode: 301,
+      }
+    }
+  }
+
+  if (req.method !== 'GET') {
+    res.statusCode = 405
+    res.setHeader("Content-Type", "application/json")
+    res.write(JSON.stringify({ error: "method not allowed" }))
+    res.end()
+    return {
+      props: {}
+    }
+  }
+
+  let siteMaps: types.SiteMap[]
+  if (sitemapOnlyPageUrlOverridden) {
+    siteMaps = await getOnlyUrlOverriddenSiteMaps()
+  } else {
+    siteMaps = await getSiteMaps()
+  }
+
+  // cache sitemap for up to one hour
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=3600, max-age=3600, stale-while-revalidate=3600'
+  )
+  res.setHeader('Content-Type', 'text/xml')
+  res.write(createSitemap(siteMaps[0].canonicalPageMap))
+  res.end()
+
+  return {
+    props: {}
+  }
+}
+
+const createSitemap = (
+  canonicalPageMap: CanonicalPageMap
+) => `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+        <loc>${host}</loc>
+      </url>
+
+      <url>
+        <loc>${host}/</loc>
+      </url>
+
+      ${Object.keys(canonicalPageMap)
+        .map((canonicalPagePath) =>
+          `
+            <url>
+              <loc>${host}/${canonicalPagePath}</loc>
+            </url>
+          `.trim()
+        )
+        .join('')}
+    </urlset>
+    `
+
+const SiteMapXml: React.FC = () => null
+
+export default SiteMapXml

--- a/site.config.js
+++ b/site.config.js
@@ -47,5 +47,10 @@ module.exports = {
   //   '/foo': '067dd719a912471ea9a3ac10710e7fdf',
   //   '/bar': '0be6efce9daf42688f65c76b89f8eb27'
   // }
-  pageUrlOverrides: null
+  pageUrlOverrides: null,
+
+  // if you want to generate sitemap.xml only with url overrided
+  // by `pageUrlOverrides` prop, that will make SEO robots only to
+  // index pages that urls have been overridden
+  sitemapOnlyPageUrlOverridden: false
 }

--- a/site.config.js
+++ b/site.config.js
@@ -52,5 +52,8 @@ module.exports = {
   // if you want to generate sitemap.xml only with url overrided
   // by `pageUrlOverrides` prop, that will make SEO robots only to
   // index pages that urls have been overridden
-  sitemapOnlyPageUrlOverridden: false
+  sitemapOnlyPageUrlOverridden: false,
+
+  // make pages `sitemap.xml` and `robots.txt` without `/api` prefix
+  removeApiPrefixFromSitemapAndRobotsTxtPages: false
 }


### PR DESCRIPTION
This can be more SEO friendly.

This PR is duplicate of https://github.com/transitive-bullshit/nextjs-notion-starter-kit/pull/170 , but:

1. With optional switch to this functionality (by `removeApiPrefixFromSitemapAndRobotsTxtPages: true`)
2. Added functionality of https://github.com/transitive-bullshit/nextjs-notion-starter-kit/pull/188